### PR TITLE
Support `if exists` to `drop table` statement

### DIFF
--- a/lib/Parse/Dia/SQL/Output.pm
+++ b/lib/Parse/Dia/SQL/Output.pm
@@ -550,15 +550,21 @@ CLASS:
       next;
     }
 
-    $sqlstr .=
-        qq{drop table }
-      . $object->{name}
-      . $self->{end_of_statement}
-      . $self->{newline};
+    $sqlstr .= $self->_get_drop_schema_sql($object->{name});
   }
 
   return $sqlstr;
 
+}
+
+sub _get_drop_schema_sql {
+  my ($self, $tablename) = @_;
+
+  return
+      qq{drop table if exists }
+    . $self->_quote_identifier($tablename)
+    . $self->{end_of_statement}
+    . $self->{newline};
 }
 
 # Create revoke sql

--- a/lib/Parse/Dia/SQL/Output/DB2.pm
+++ b/lib/Parse/Dia/SQL/Output/DB2.pm
@@ -118,6 +118,21 @@ sub _create_constraint_name {
   #  return $self->{utils}->mangle_name( $constraint_name, $self->{object_name_max_length} - 4 );
 }
 
+=head2 _get_drop_schema_sql
+
+DB2 do not support keyword 'if exists' in 'drop table' statement
+
+=cut
+
+sub _get_drop_schema_sql {
+  my ($self, $tablename) = @_;
+
+  return
+      qq{drop table $tablename}
+    . $self->{end_of_statement}
+    . $self->{newline};
+}
+
 1;
 
 __END__

--- a/lib/Parse/Dia/SQL/Output/MySQL.pm
+++ b/lib/Parse/Dia/SQL/Output/MySQL.pm
@@ -72,43 +72,6 @@ sub _get_drop_index_sql {
     . $self->{newline};
 }
 
-=head2 get_schema_drop
-
-create drop table for all tables using MySQL syntax:
-
-  drop table t if exists
-
-=cut
-
-sub get_schema_drop {
-  my $self   = shift;
-  my $sqlstr = '';
-
-  return unless $self->_check_classes();
-
-CLASS:
-  foreach my $object (@{ $self->{classes} }) {
-    next CLASS if ($object->{type} ne q{table});
-
-    # Sanity checks on internal state
-    if (!defined($object)
-      || ref($object) ne q{HASH}
-      || !exists($object->{name}))
-    {
-      $self->{log}
-        ->error(q{Error in table input - cannot create drop table sql!});
-      next;
-    }
-
-    $sqlstr .=
-        qq{drop table if exists }
-      . $self->_quote_identifier($object->{name})
-      . $self->{end_of_statement}
-      . $self->{newline};
-  }
-
-  return $sqlstr;
-}
 
 1;
 

--- a/lib/Parse/Dia/SQL/Output/Oracle.pm
+++ b/lib/Parse/Dia/SQL/Output/Oracle.pm
@@ -59,6 +59,21 @@ sub _get_drop_index_sql {
     . $self->{newline};
 }
 
+=head2 _get_drop_schema_sql
+
+Oracle do not support keyword 'if exists' in 'drop table' statement
+
+=cut
+
+sub _get_drop_schema_sql {
+  my ($self, $tablename) = @_;
+
+  return
+      qq{drop table $tablename}
+    . $self->{end_of_statement}
+    . $self->{newline};
+}
+
 
 
 1;

--- a/lib/Parse/Dia/SQL/Output/Sas.pm
+++ b/lib/Parse/Dia/SQL/Output/Sas.pm
@@ -46,6 +46,21 @@ sub new {
   return $self;
 }
 
+=head2 _get_drop_schema_sql
+
+Sas do not support keyword 'if exists' in 'drop table' statement
+
+=cut
+
+sub _get_drop_schema_sql {
+  my ($self, $tablename) = @_;
+
+  return
+      qq{drop table $tablename}
+    . $self->{end_of_statement}
+    . $self->{newline};
+}
+
 
 1;
 


### PR DESCRIPTION
Fixes #8 

Oracle, DB2 and Sas do not support `if exists` keyword in `drop table` statement.

So these three database's drop table statement will not change.

The reason this PR have no new test is, the two possible case this PR would bring, already covered in existing test https://github.com/aff/Parse-Dia-SQL/blob/master/t/640-output-get-schema-drop-sql.t and https://github.com/aff/Parse-Dia-SQL/blob/master/t/646-output-get-schema-drop-sql-mysql-innodb.t